### PR TITLE
Fix database connection handling

### DIFF
--- a/app/__tests__/signup.test.js
+++ b/app/__tests__/signup.test.js
@@ -40,7 +40,7 @@ describe('POST /api/signup', () => {
 
     expect(res.status).toBe(201);
     const data = await res.json();
-    expect(data).toEqual({ message: 'User Created' });
+    expect(data).toEqual({ success: true, message: 'User Created' });
   });
 
   it('should return an error for missing credentials', async () => {


### PR DESCRIPTION
## Summary
- defer database env validation until connection and allow reusing existing Mongoose connection
- align signup test with API response structure

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688f8c96be908333b15872f0256f4c85